### PR TITLE
Fix Composer namespace definition

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
   },
   "autoload": {
     "psr-4": {
-      "Logasaurus": "src"
+      "Logasaurus\\": "src"
     },
     "classmap": ["src"]
   },


### PR DESCRIPTION
I think this will fix the Packagist release errors

example from GrumPHP: https://github.com/phpro/grumphp/blob/master/composer.json